### PR TITLE
Specify dependencies according to semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,22 +11,22 @@ keywords = ["DMG", "Apple"]
 categories = ["command-line-utilities", "encoding", "filesystem", "parsing"]
 
 [dependencies]
-itertools = "0.9.0"
-clap = "2.33.1"
-bincode = "1.3.1"
-serde = { version = "1.0", features = ["derive"] }
-ring = "0.16.15"
+itertools = "0.9"
+clap = "2"
+bincode = "1"
+serde = { version = "1", features = ["derive"] }
+ring = "0.16"
 openssl = { version = "0.10", features = ["vendored"] }
-plist = "1.0.0"
+plist = "1"
 num-traits = "0.2"
 num-derive = "0.3"
-flate2 = "1.0.16"
-bzip2 = "0.4.1"
-adc = "0.1.0"
-lzfse = "0.1.0"
+flate2 = "1"
+bzip2 = "0.4"
+adc = "0.1"
+lzfse = "0.1"
 
 [dev-dependencies]
-file_diff = "1.0.0"
+file_diff = "1"
 
 [lib]
 name = "dmgwiz"


### PR DESCRIPTION
If the Cargo.toml doesn't specify an operator for crate versions, the caret operator (`^`) is used (https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html). This means if you specify a version like "1.2.3", cargo interprets that as "^1.2.3", which means it is free to update to any larger version 1.y.z, according to the rules of semantic versioning (https://github.com/steveklabnik/semver#requirements).

This is a sensible default, since it allows getting bugfix updates for dependencies without having to update their versions every time. However, the implicit caret requirement is not obvious. People might assume that a version spec like "1.2.3" pins the dependency to exactly this version.

To avoid this confusion, this PR truncates the dependency versions to only the relevant parts, i.e. those that won't change under semver-compatible updates.