### PR TITLE
Add a feature to disable encryption support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ itertools = "0.9.0"
 clap = "2.33.1"
 bincode = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
-ring = "0.16.15"
-openssl = { version = "0.10", features = ["vendored"] }
+ring = { version = "0.16.15", optional = true }
 plist = "1.0.0"
 num-traits = "0.2"
 num-derive = "0.3"
@@ -24,6 +23,11 @@ flate2 = "1.0.16"
 bzip2 = "0.4.1"
 adc = "0.1.0"
 lzfse = "0.1.0"
+
+[dependencies.openssl]
+version = "0.10"
+features = ["vendored"]
+optional = true
 
 [dev-dependencies]
 file_diff = "1.0.0"
@@ -35,3 +39,8 @@ path = "src/lib.rs"
 [[bin]]
 name = "dmgwiz"
 path = "src/main.rs"
+required-features = ["crypto"]
+
+[features]
+default = ["crypto"]
+crypto = ["openssl", "ring"]

--- a/README.md
+++ b/README.md
@@ -12,11 +12,8 @@ DmgWiz lets you extract raw filesystem data from compressed and encrypted DMG fi
 DmgWiz is both a CLI tool and a Rust crate so it can be integrated into other projects.
 
 
-[API Documentation](https://docs.rs/dmgwiz)
-----------
-
 CLI Usage
------
+---------
 
     dmgwiz [OPTIONS] <INPUT> [SUBCOMMAND]
 
@@ -37,6 +34,17 @@ CLI Usage
 
     dmgwiz <INPUT> extract [-n <partition number>] -o <output>
     
+
+Crate Usage
+-----------
+
+DmgWiz can also be used as a crate in other Rust projects. Please see the [API Documentation](https://docs.rs/dmgwiz) and `main.rs` for examples how to use it.
+
+Support for encrypted DMGs can be disabled to reduce the compilation time and amount of C code. To do this, add the `default-features = false` in your `Cargo.toml`:
+```TOML
+[dependencies]
+dmgwiz = {version = "0.2", default-features = false}
+```
 
 References
 ----------

--- a/src/crypto/header.rs
+++ b/src/crypto/header.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+/// Header used for encrypted DMGs
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct EncryptedDmgHeader {
+    signature: [char; 8],
+    pub version: u32,
+    pub enc_iv_size: u32,
+    unk1: u32,
+    unk2: u32,
+    pub data_enc_key_bits: u32,
+    unk4: u32,
+    pub hmac_key_bits: u32,
+    pub uuid: [u8; 16],
+    pub blocksize: u32,
+    pub datasize: u64,
+    pub dataoffset: u64,
+    unk6: [u8; 24],
+    pub kdf_algorithm: u32,
+    pub kdf_prng_algorithm: u32,
+    pub kdf_iteration_count: u32,
+    pub kdf_salt_len: u32,
+    pub kdf_salt: [u8; 32],
+    pub blob_enc_iv_size: u32,
+    pub blob_enc_iv: [u8; 32],
+    pub blob_enc_key_bits: u32,
+    pub blob_enc_algorithm: u32,
+    pub blob_enc_padding: u32,
+    pub blob_enc_mode: u32,
+    pub encrypted_keyblob_size: u32,
+    pub encrypted_keyblob1: [u8; 32],
+    pub encrypted_keyblob2: [u8; 32],
+}
+
+impl EncryptedDmgHeader {
+    pub fn get_signature(&self) -> String {
+        self.signature.iter().collect::<String>()
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,3 @@
+pub mod header;
+#[cfg(feature = "crypto")]
+pub mod reader;

--- a/src/crypto/reader.rs
+++ b/src/crypto/reader.rs
@@ -10,11 +10,11 @@ use openssl::pkey::PKey;
 use openssl::sign::Signer;
 use openssl::symm::{decrypt as openssl_decrypt, Cipher, Crypter, Mode};
 use ring::pbkdf2;
-use serde::{Deserialize, Serialize};
 
 static PBKDF2_ALG: pbkdf2::Algorithm = pbkdf2::PBKDF2_HMAC_SHA1;
 
-use super::{Error, Result, Verbosity};
+use super::header::EncryptedDmgHeader;
+use crate::{Error, Result, Verbosity};
 
 // how can i use macro from super?
 macro_rules! printDebug {
@@ -23,44 +23,6 @@ macro_rules! printDebug {
             println!($($arg)*);
         }
     })
-}
-
-/// Header used for encrypted DMGs
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-pub struct EncryptedDmgHeader {
-    signature: [char; 8],
-    version: u32,
-    enc_iv_size: u32,
-    unk1: u32,
-    unk2: u32,
-    data_enc_key_bits: u32,
-    unk4: u32,
-    hmac_key_bits: u32,
-    uuid: [u8; 16],
-    blocksize: u32,
-    datasize: u64,
-    dataoffset: u64,
-    unk6: [u8; 24],
-    kdf_algorithm: u32,
-    kdf_prng_algorithm: u32,
-    kdf_iteration_count: u32,
-    kdf_salt_len: u32,
-    kdf_salt: [u8; 32],
-    blob_enc_iv_size: u32,
-    blob_enc_iv: [u8; 32],
-    blob_enc_key_bits: u32,
-    blob_enc_algorithm: u32,
-    blob_enc_padding: u32,
-    blob_enc_mode: u32,
-    encrypted_keyblob_size: u32,
-    encrypted_keyblob1: [u8; 32],
-    encrypted_keyblob2: [u8; 32],
-}
-
-impl EncryptedDmgHeader {
-    pub fn get_signature(&self) -> String {
-        self.signature.iter().collect::<String>()
-    }
 }
 
 /// Reader to read from encrypted DMGs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,13 @@ use std::io::prelude::*;
 use std::io::Cursor;
 use std::io::SeekFrom;
 
-mod encrypted_reader;
+mod crypto;
 mod error;
 
-use encrypted_reader::EncryptedDmgHeader;
-pub use encrypted_reader::EncryptedDmgReader;
+use crypto::header::EncryptedDmgHeader;
+
+#[cfg(feature = "crypto")]
+pub use crypto::reader::EncryptedDmgReader;
 pub use error::{Error, Result};
 
 const SECTOR_SIZE: usize = 512;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,9 @@
 use file_diff::diff_files;
 use std::fs::File;
 
-use dmgwiz::{DmgWiz, EncryptedDmgReader, Verbosity};
+#[cfg(feature = "crypto")]
+use dmgwiz::EncryptedDmgReader;
+use dmgwiz::{DmgWiz, Verbosity};
 
 #[test]
 fn test_reader() {
@@ -64,12 +66,14 @@ fn test_extract_partition() {
     ));
 }
 
+#[cfg(feature = "crypto")]
 #[test]
 fn test_encrypted_reader() {
     let input = File::open("tests/input_aes256.dmg").unwrap();
     EncryptedDmgReader::from_reader(input, "test123", Verbosity::None).unwrap();
 }
 
+#[cfg(feature = "crypto")]
 #[test]
 fn test_encrypted_reader_read_all() {
     let input = File::open("tests/input_aes256.dmg").unwrap();


### PR DESCRIPTION
By disabling the "crypto" default feature, users can opt-out of the support for encrypted DMG files. One may want to do that to reduce compile time (~1 min in my tests), reduce the binary size, or reduce the amount of C code that gets compiled in.