### PR TITLE
Avoid temporary buffers for decompression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
       with:
           toolchain: stable
           override: true
-          components: rustfmt
+          components: clippy
     - uses: actions-rs/cargo@v1
       with:
         command: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,8 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adc"
-version = "0.1.0"
-source = "git+https://github.com/ra-kete/adc-rs.git?branch=read-trait#f7c149c8066689798f86872191550d07b0eff722"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "dmgwiz"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
- "adc 0.1.0 (git+https://github.com/ra-kete/adc-rs.git?branch=read-trait)",
+ "adc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bzip2 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -537,7 +537,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum adc 0.1.0 (git+https://github.com/ra-kete/adc-rs.git?branch=read-trait)" = "<none>"
+"checksum adc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83d4c33c559b31d733cc094734ec69ea629cbe37f528fa68232bc59e92d49d32"
 "checksum adler 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,9 @@
 [[package]]
 name = "adc"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/ra-kete/adc-rs.git?branch=read-trait#f7c149c8066689798f86872191550d07b0eff722"
 dependencies = [
- "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -129,8 +129,9 @@ dependencies = [
 name = "dmgwiz"
 version = "0.2.0"
 dependencies = [
- "adc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adc 0.1.0 (git+https://github.com/ra-kete/adc-rs.git?branch=read-trait)",
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bzip2 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "file_diff 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -536,7 +537,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum adc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be12bd757dcaf2115a82029e5659d0f89c7fabe851bc100d2d296a317caa82d7"
+"checksum adc 0.1.0 (git+https://github.com/ra-kete/adc-rs.git?branch=read-trait)" = "<none>"
 "checksum adler 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmgwiz"
 description = "Extract filesystem data from DMG files"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Felix Seele <fseele@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities", "encoding", "filesystem", "parsing"]
 itertools = "0.9"
 clap = "2"
 bincode = "1"
+byteorder = "1"
 serde = { version = "1", features = ["derive"] }
 ring = { version = "0.16", optional = true }
 plist = "1"
@@ -21,7 +22,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 flate2 = "1"
 bzip2 = "0.4"
-adc = "0.1"
+adc = { git = "https://github.com/ra-kete/adc-rs.git", branch = "read-trait" }
 lzfse = "0.1"
 
 [dependencies.openssl]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 flate2 = "1"
 bzip2 = "0.4"
-adc = { git = "https://github.com/ra-kete/adc-rs.git", branch = "read-trait" }
+adc = "0.2"
 lzfse = "0.1"
 
 [dependencies.openssl]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ dmgwiz = {version = "0.2", default-features = false}
 Changelog
 ---------
 
+0.2.1
+- Removed temporary buffers for decompression
+
 0.2.0
 - Added support for comment chunks
 - Added `CFName` as fallback in case the `Name` attribute is not set

--- a/src/crypto/reader.rs
+++ b/src/crypto/reader.rs
@@ -152,11 +152,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use std::fs::File;
+    /// use std::{fs::File, io::BufWriter};
     /// use dmgwiz::{EncryptedDmgReader, Verbosity};
     ///
     /// let input = File::open("tests/input_aes256.dmg").unwrap();
-    /// let output = File::create("tests/output.dmg").unwrap();
+    /// let outfile = File::create("tests/output.dmg").unwrap();
+    /// let output = BufWriter::new(outfile);
+    ///
     /// let mut reader = EncryptedDmgReader::from_reader(input, "test123", Verbosity::None).unwrap();
     /// match reader.read_all(output) {
     ///     Err(err) => panic!(format!("error while decrypting: {}", err)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,11 +408,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use std::fs::File;
+    /// use std::{fs::File, io::BufWriter};
     /// use dmgwiz::{DmgWiz, Verbosity};
     ///
     /// let input = File::open("tests/input_zlib.dmg").unwrap();
-    /// let output = File::create("tests/output_zlib.bin").unwrap();
+    /// let outfile = File::create("tests/output_zlib.bin").unwrap();
+    /// let output = BufWriter::new(outfile);
+    ///
     /// let mut wiz = DmgWiz::from_reader(input, Verbosity::None).unwrap();
     /// match wiz.extract_all(output) {
     ///     Err(err) => panic!(format!("error while extracting: {}", err)),
@@ -444,11 +446,13 @@ where
     /// # Example
     ///
     /// ```
-    /// use std::fs::File;
+    /// use std::{fs::File, io::BufWriter};
     /// use dmgwiz::{DmgWiz, Verbosity};
     ///
     /// let input = File::open("tests/input_zlib.dmg").unwrap();
-    /// let output = File::create("tests/output_zlib.bin").unwrap();
+    /// let outfile = File::create("tests/output_zlib.bin").unwrap();
+    /// let output = BufWriter::new(outfile);
+    ///
     /// let mut wiz = DmgWiz::from_reader(input, Verbosity::None).unwrap();
     /// match wiz.extract_partition(output, 0) {
     ///     Err(err) => panic!(format!("error while extracting: {}", err)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@ use bincode::Options;
 use bzip2::read::BzDecoder;
 use flate2::read::ZlibDecoder;
 use itertools::Itertools;
-use lzfse::decode_buffer as lzfse_decode_buffer;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::cmp::Ordering;
 use std::fmt;
+use std::io;
 use std::io::prelude::*;
 use std::io::Cursor;
 use std::io::SeekFrom;
@@ -481,24 +481,6 @@ where
             )));
         }
 
-        // allocate buffers for in and output
-        let max_compressed_length = partition
-            .blkx_table
-            .chunks
-            .iter()
-            .fold(0, |max, c| cmp::max(max, c.compressed_length))
-            as usize;
-        let max_sector_count = partition
-            .blkx_table
-            .chunks
-            .iter()
-            .fold(0, |max, c| cmp::max(max, c.sector_count))
-            as usize;
-
-        let mut inbuf = vec![0; max_compressed_length];
-        // need to add one additional byte for lzfse decompression
-        let mut outbuf = vec![0; (max_sector_count * SECTOR_SIZE) + 1];
-
         let mut sectors_written = 0;
 
         for (chunk_num, chunk) in partition.blkx_table.chunks.iter().enumerate() {
@@ -522,16 +504,6 @@ where
                 return Ok(sectors_written as usize * SECTOR_SIZE);
             }
 
-            // position input at start of chunk
-            self.input
-                .seek(SeekFrom::Start(self.data_offset + chunk.compressed_offset))?;
-
-            let in_len = chunk.compressed_length as usize;
-            let out_len = chunk.sector_count as usize * SECTOR_SIZE;
-
-            // read compressed chunk
-            self.input.read_exact(&mut inbuf[0..in_len])?;
-
             // usually sectors are consecutive, but let's check to be sure.
             // if chunk.sector_number is less than what we have already written we have a problem.
             // otherwise just write NULL sectors.
@@ -551,22 +523,32 @@ where
                 }
                 Ordering::Equal => (),
             }
+
+            let in_len = chunk.compressed_length as usize;
+            let out_len = chunk.sector_count as usize * SECTOR_SIZE;
+
+            let chunk_offset = self.data_offset + chunk.compressed_offset;
+            self.input.seek(SeekFrom::Start(chunk_offset))?;
+            let mut chunk_input = BoundedReader {
+                inner: &mut self.input,
+                len: in_len,
+            };
+
             // decompress
             let bytes_read = match chunk_type {
                 ChunkType::Ignore | ChunkType::Zero | ChunkType::Comment => {
-                    fill_zero(&mut outbuf[0..out_len])
+                    write_zero(&mut output, out_len)
                 }
-                ChunkType::Raw => copy(&inbuf[0..in_len], &mut outbuf[0..out_len]),
-                ChunkType::ADC => decode_adc(&inbuf[0..in_len], &mut outbuf[0..out_len]),
-                ChunkType::ZLIB => decode_zlib(&inbuf[0..in_len], &mut outbuf[0..out_len]),
-                ChunkType::BZLIB => decode_bzlib(&inbuf[0..in_len], &mut outbuf[0..out_len]),
-                // lzfse buffer needs to be one byte larger to tell if the buffer was large enough
-                ChunkType::LZFSE => decode_lzfse(&inbuf[0..in_len], &mut outbuf[0..(out_len + 1)]),
+                ChunkType::Raw => copy(&mut chunk_input, &mut output),
+                ChunkType::ADC => decode_adc(&mut chunk_input, &mut output),
+                ChunkType::ZLIB => decode_zlib(&mut chunk_input, &mut output),
+                ChunkType::BZLIB => decode_bzlib(&mut chunk_input, &mut output),
+                ChunkType::LZFSE => decode_lzfse(&mut chunk_input, &mut output),
                 ChunkType::Term => unreachable!(),
             };
 
             match bytes_read {
-                Some(val) if val == out_len => printDebug!(self, "decompressed {} bytes", val),
+                Ok(val) if val == out_len => printDebug!(self, "decompressed {} bytes", val),
                 _ => {
                     return Err(Error::Decompress {
                         partition_num,
@@ -576,8 +558,6 @@ where
                 }
             };
 
-            // write to ouput
-            output.write_all(&outbuf[0..out_len])?;
             sectors_written += chunk.sector_count;
         }
 
@@ -599,45 +579,50 @@ where
     }
 }
 
-fn decode_zlib(inbuf: &[u8], outbuf: &mut [u8]) -> Option<usize> {
-    let mut z = ZlibDecoder::new(&inbuf[..]);
-    match z.read_exact(outbuf) {
-        Err(_) => None,
-        Ok(_) => Some(outbuf.len()),
+struct BoundedReader<R> {
+    inner: R,
+    len: usize,
+}
+
+impl<R: Read> Read for BoundedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let max_len = cmp::min(self.len, buf.len());
+        let read_len = self.inner.read(&mut buf[..max_len])?;
+        self.len -= read_len;
+        Ok(read_len)
     }
 }
 
-fn decode_bzlib(inbuf: &[u8], outbuf: &mut [u8]) -> Option<usize> {
-    let mut z = BzDecoder::new(&inbuf[..]);
-    match z.read_exact(outbuf) {
-        Err(_) => None,
-        Ok(_) => Some(outbuf.len()),
-    }
+fn decode_zlib<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
+    let mut z = ZlibDecoder::new(src);
+    let len = io::copy(&mut z, dest)?;
+    Ok(len as usize)
 }
 
-fn decode_lzfse(inbuf: &[u8], outbuf: &mut [u8]) -> Option<usize> {
-    match lzfse_decode_buffer(inbuf, outbuf) {
-        Err(_) => None,
-        Ok(val) => Some(val),
-    }
+fn decode_bzlib<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
+    let mut bz = BzDecoder::new(src);
+    let len = io::copy(&mut bz, dest)?;
+    Ok(len as usize)
 }
 
-fn decode_adc(inbuf: &[u8], outbuf: &mut [u8]) -> Option<usize> {
-    let mut z = AdcDecoder::new(&inbuf[..]);
-    match z.decompress_into(outbuf) {
-        Ok(val) => Some(val),
-        Err(_) => None,
-    }
+fn decode_lzfse<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
+    unimplemented!("need to adapt lzfse crate first");
 }
 
-fn fill_zero(outbuf: &mut [u8]) -> Option<usize> {
-    for i in &mut outbuf[..] {
-        *i = 0
-    }
-    Some(outbuf.len())
+fn decode_adc<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
+    let mut adc = AdcDecoder::new(src);
+    //let len = io::copy(&mut adc, dest)?;
+    //Ok(len as usize)
+    unimplemented!("need to impl Read for AdcDecoder first");
 }
 
-fn copy(inbuf: &[u8], outbuf: &mut [u8]) -> Option<usize> {
-    outbuf.copy_from_slice(inbuf);
-    Some(outbuf.len())
+fn write_zero<W: Write>(w: &mut W, len: usize) -> Result<usize> {
+    let mut zeros = io::repeat(0).take(len as u64);
+    io::copy(&mut zeros, w)?;
+    Ok(len)
+}
+
+fn copy<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
+    let len = io::copy(src, dest)?;
+    Ok(len as usize)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use std::io::SeekFrom;
 
 mod crypto;
 mod error;
+mod lzfse;
 
 use crypto::header::EncryptedDmgHeader;
 
@@ -610,14 +611,15 @@ fn decode_bzlib<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
 }
 
 fn decode_lzfse<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
-    unimplemented!("need to adapt lzfse crate first");
+    let mut lz = lzfse::Decoder::new(src);
+    let len = io::copy(&mut lz, dest)?;
+    Ok(len as usize)
 }
 
 fn decode_adc<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
     let mut adc = AdcDecoder::new(src);
-    //let len = io::copy(&mut adc, dest)?;
-    //Ok(len as usize)
-    unimplemented!("need to impl Read for AdcDecoder first");
+    let len = io::copy(&mut adc, dest)?;
+    Ok(len as usize)
 }
 
 fn write_zero<W: Write>(w: &mut W, len: usize) -> Result<usize> {

--- a/src/lzfse.rs
+++ b/src/lzfse.rs
@@ -1,0 +1,194 @@
+use byteorder::{ReadBytesExt, LE};
+use std::{
+    cmp,
+    collections::VecDeque,
+    io::{self, Read},
+};
+
+pub struct Decoder<R> {
+    input: R,
+    buf: Option<VecDeque<u8>>,
+}
+
+impl<R: Read> Decoder<R> {
+    pub fn new(input: R) -> Self {
+        Self { input, buf: None }
+    }
+
+    fn fill_buff(&mut self) -> io::Result<()> {
+        let next_block = decode_block(&mut self.input)?;
+        self.buf = next_block.map(Into::into);
+        Ok(())
+    }
+}
+
+impl<R: Read> Read for Decoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.buf.is_none() {
+            self.fill_buff()?;
+        }
+
+        let source = match &mut self.buf {
+            Some(b) => b,
+            None => return Ok(0),
+        };
+
+        let read_len = cmp::min(source.len(), buf.len());
+        source
+            .drain(..read_len)
+            .zip(buf.iter_mut())
+            .for_each(|(src, dst)| *dst = src);
+
+        Ok(read_len)
+    }
+}
+
+const MAGIC_ENDOFSTREAM: [u8; 4] = *b"bvx$";
+const MAGIC_UNCOMPRESSED: [u8; 4] = *b"bvx-";
+const MAGIC_LZFSE_V1: [u8; 4] = *b"bvx1";
+const MAGIC_LZFSE_V2: [u8; 4] = *b"bvx2";
+const MAGIC_LZVN: [u8; 4] = *b"bvxn";
+
+const MAGIC_SIZE: usize = 4;
+const HEADER_SIZE_UNCOMPRESSED: usize = 4;
+const HEADER_SIZE_LZFSE_V1: usize = 768;
+const HEADER_SIZE_LZFSE_V2: usize = 28;
+const HEADER_SIZE_LZVN: usize = 8;
+
+#[derive(Debug)]
+struct Header {
+    raw: Vec<u8>,
+    n_raw_bytes: u32,
+    n_payload_bytes: u32,
+}
+
+impl Header {
+    fn uncompressed<R: Read>(input: &mut R) -> io::Result<Self> {
+        let mut raw = vec![0; HEADER_SIZE_UNCOMPRESSED];
+        input.read_exact(&mut raw)?;
+
+        let n_raw_bytes = parse_u32(&raw)?;
+
+        Ok(Self {
+            raw,
+            n_raw_bytes,
+            n_payload_bytes: n_raw_bytes,
+        })
+    }
+
+    fn lzfse_v1<R: Read>(input: &mut R) -> io::Result<Self> {
+        let mut raw = vec![0; HEADER_SIZE_LZFSE_V1];
+        input.read_exact(&mut raw)?;
+
+        let n_raw_bytes = parse_u32(&raw)?;
+        let n_literal_payload_bytes = parse_u32(&raw[20..])?;
+        let n_lmd_payload_bytes = parse_u32(&raw[24..])?;
+        let n_payload_bytes = n_literal_payload_bytes + n_lmd_payload_bytes;
+
+        Ok(Self {
+            raw,
+            n_raw_bytes,
+            n_payload_bytes,
+        })
+    }
+
+    fn lzfse_v2<R: Read>(input: &mut R) -> io::Result<Self> {
+        let mut raw = vec![0; HEADER_SIZE_LZFSE_V2];
+        input.read_exact(&mut raw)?;
+
+        let n_raw_bytes = parse_u32(&raw)?;
+
+        let packed1 = parse_u64(&raw[4..])?;
+        let packed2 = parse_u64(&raw[12..])?;
+
+        let n_literal_payload_bytes = parse_packed_field(packed1, 20, 20);
+        let n_lmd_payload_bytes = parse_packed_field(packed2, 40, 20);
+        let header_size = parse_u32(&raw[20..])?;
+        let remaining_header_bytes = header_size - (MAGIC_SIZE + HEADER_SIZE_LZFSE_V2) as u32;
+
+        let n_payload_bytes =
+            remaining_header_bytes + n_literal_payload_bytes + n_lmd_payload_bytes;
+
+        Ok(Self {
+            raw,
+            n_raw_bytes,
+            n_payload_bytes,
+        })
+    }
+
+    fn lzvn<R: Read>(input: &mut R) -> io::Result<Self> {
+        let mut raw = vec![0; HEADER_SIZE_LZVN];
+        input.read_exact(&mut raw)?;
+
+        let n_raw_bytes = parse_u32(&raw)?;
+        let n_payload_bytes = parse_u32(&raw[4..])?;
+
+        Ok(Self {
+            raw,
+            n_raw_bytes,
+            n_payload_bytes,
+        })
+    }
+
+    fn size(&self) -> usize {
+        self.raw.len()
+    }
+}
+
+fn parse_u32(mut bytes: &[u8]) -> io::Result<u32> {
+    bytes.read_u32::<LE>()
+}
+
+fn parse_u64(mut bytes: &[u8]) -> io::Result<u64> {
+    bytes.read_u64::<LE>()
+}
+
+fn parse_packed_field(packed: u64, offset: usize, nbits: usize) -> u32 {
+    let mask = (1 << nbits) - 1;
+    ((packed >> offset) & mask) as u32
+}
+
+fn decode_block<R: Read>(input: &mut R) -> io::Result<Option<Vec<u8>>> {
+    let mut magic = [0; 4];
+    input.read_exact(&mut magic)?;
+
+    let header = match magic {
+        MAGIC_UNCOMPRESSED => Header::uncompressed(input)?,
+        MAGIC_LZFSE_V1 => Header::lzfse_v1(input)?,
+        MAGIC_LZFSE_V2 => Header::lzfse_v2(input)?,
+        MAGIC_LZVN => Header::lzvn(input)?,
+        MAGIC_ENDOFSTREAM => return Ok(None),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid block magic",
+            ))
+        }
+    };
+
+    // Read the full block (header + payload) into a buffer that can be passed
+    // to `decode_buffer`. Also append a dummy ENDOFSTREAM header to ensure
+    // we don't get an error in the success case.
+    let header_size = MAGIC_SIZE + header.size();
+    let payload_size = header.n_payload_bytes as usize;
+    let mut src = vec![0; header_size + payload_size + 4];
+    src[..MAGIC_SIZE].copy_from_slice(&magic);
+    src[MAGIC_SIZE..header_size].copy_from_slice(&header.raw);
+    input.read_exact(&mut src[header_size..][..payload_size])?;
+    src[header_size + payload_size..].copy_from_slice(&MAGIC_ENDOFSTREAM);
+
+    let mut dst = vec![0; header.n_raw_bytes as usize];
+
+    match lzfse::decode_buffer(&src, &mut dst) {
+        Err(lzfse::Error::BufferTooSmall) => (),
+        Err(lzfse::Error::CompressFailed) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid input data",
+            ))
+        }
+        Ok(_) => unreachable!("we always fill the whole out_buf"),
+    }
+
+    Ok(Some(dst))
+}

--- a/src/lzfse.rs
+++ b/src/lzfse.rs
@@ -5,6 +5,7 @@ use std::{
     io::{self, Read},
 };
 
+/// Wrapper around the lzfse library which implements the `Read` trait to access decompressed data
 pub struct Decoder<R> {
     input: R,
     buf: Option<VecDeque<u8>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn error(msg: String) -> ! {
 
 fn main() {
     let matches = App::new("dmgwiz")
-        .version("0.2")
+        .version("0.2.1")
         .author("Felix Seele <fseele@gmail.com>")
         .about("Extract filesystem data from DMG files")
         .arg(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 use file_diff::diff_files;
 use std::fs::File;
+use std::io::BufWriter;
 
 #[cfg(feature = "crypto")]
 use dmgwiz::EncryptedDmgReader;
@@ -15,7 +16,9 @@ fn test_reader() {
 
 fn extract_all_test(inpath: &str, outpath: &str) {
     let input = File::open(inpath).unwrap();
-    let output = File::create(outpath).unwrap();
+    let outfile = File::create(outpath).unwrap();
+    let output = BufWriter::new(outfile);
+
     let mut wiz = DmgWiz::from_reader(input, Verbosity::None).unwrap();
     let bytes_written = wiz.extract_all(output).unwrap();
     assert_eq!(bytes_written, 10510336);
@@ -55,7 +58,9 @@ fn test_extract_all_lzma() {
 #[test]
 fn test_extract_partition() {
     let input = File::open("tests/input_zlib.dmg").unwrap();
-    let output = File::create("tests/output_zlib_p4.bin").unwrap();
+    let outfile = File::create("tests/output_zlib_p4.bin").unwrap();
+    let output = BufWriter::new(outfile);
+
     let mut wiz = DmgWiz::from_reader(input, Verbosity::None).unwrap();
     let bytes_written = wiz.extract_partition(output, 4).unwrap();
 
@@ -77,7 +82,9 @@ fn test_encrypted_reader() {
 #[test]
 fn test_encrypted_reader_read_all() {
     let input = File::open("tests/input_aes256.dmg").unwrap();
-    let output = File::create("tests/output_aes256.dmg").unwrap();
+    let outfile = File::create("tests/output_aes256.dmg").unwrap();
+    let output = BufWriter::new(outfile);
+
     let mut reader = EncryptedDmgReader::from_reader(input, "test123", Verbosity::None).unwrap();
     let bytes_written = reader.read_all(output).unwrap();
 


### PR DESCRIPTION
Some DMG files contain very large chunks (in the order of multiple GB). Decompressing those into a buffer means that dmgwiz can use an excessive amount of memory or even crash. To fix this, this PR removes the buffers and instead makes the decompression work on the input and output `Read` and `Write` objects directly.

This still uses an unstable version of the adc crate to get support for the `Read` trait on `AdcDecoder`. We'll have to wait for that to get merged and release before we can merge this PR.