### PR TITLE
Add XML Cleanup Function to Handle Corrupted Data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "dmgwiz"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "adc",
  "bincode",
@@ -203,6 +203,7 @@ dependencies = [
  "num-traits",
  "openssl",
  "plist",
+ "quick-xml 0.37.5",
  "ring",
  "serde",
 ]
@@ -371,9 +372,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -406,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -425,13 +426,13 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plist"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.32.0",
  "serde",
  "time",
 ]
@@ -461,6 +462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,15 +481,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -509,12 +518,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmgwiz"
 description = "Extract filesystem data from DMG files"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Felix Seele <fseele@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -24,6 +24,7 @@ flate2 = "1"
 bzip2 = "0.4"
 adc = "0.2"
 lzfse = "0.2"
+quick-xml = "0.37.5"
 
 [dependencies.openssl]
 version = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,14 @@ use flate2::read::ZlibDecoder;
 use itertools::Itertools;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
+use quick_xml::{events::Event, Reader};
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::cmp::Ordering;
 use std::fmt;
 use std::io;
 use std::io::prelude::*;
-use std::io::Cursor;
-use std::io::SeekFrom;
+use std::io::{BufReader, Cursor, SeekFrom};
 
 mod crypto;
 mod error;
@@ -355,7 +355,19 @@ where
         // read plist
         input.seek(SeekFrom::Start(header.xml_offset))?;
         let partial_reader = input.by_ref().take(header.xml_length);
-        let mut plist = plist::Value::from_reader_xml(partial_reader)?;
+
+        // Find the valid XML content and trim off any garbage data at the end
+        // This is necessary because some XML data from the header includes trailing garbage
+        // that isn't valid XML. The plist crate strictly requires well-formed XML and will
+        // fail with an error if it encounters this garbage data. By finding the exact end
+        // of the valid XML structure first, we can extract just the well-formed portion
+        // and avoid parsing errors.
+        let valid_length = find_valid_xml_offset(partial_reader)?;
+
+        // parse plist
+        input.seek(SeekFrom::Start(header.xml_offset))?;
+        let valid_reader = input.by_ref().take(valid_length as u64);
+        let mut plist = plist::Value::from_reader_xml(valid_reader)?;
 
         // get partitions from dict
         let partitions_arr = plist
@@ -639,4 +651,41 @@ fn write_zero<W: Write>(w: &mut W, len: usize) -> Result<usize> {
 fn copy<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
     let len = io::copy(src, dest)?;
     Ok(len as usize)
+}
+
+/// The function reads through the XML data tracking element nesting depth, and identifies when
+/// the root element properly closes. It returns only the position to the end of the valid XML
+/// document, effectively ignoring any trailing non-XML data.
+fn find_valid_xml_offset<R: Read>(input: R) -> Result<usize> {
+    let buf_reader = BufReader::new(input);
+    let mut xml_reader = Reader::from_reader(buf_reader);
+    xml_reader.config_mut().trim_text(false);
+
+    let mut depth = 0;
+    let mut last_valid_position = 0;
+    let mut root_element_name = Vec::new();
+    let mut buf = Vec::new();
+
+    loop {
+        match xml_reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                depth += 1;
+                if depth == 1 {
+                    root_element_name = e.name().into_inner().to_vec();
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                if depth == 1 && e.name().into_inner() == root_element_name.as_slice() {
+                    last_valid_position = xml_reader.buffer_position();
+                }
+                depth -= 1;
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(Error::Parse(Box::new(e))),
+            _ => (),
+        }
+        buf.clear();
+    }
+
+    Ok(last_valid_position as usize)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn common_args(password_req: bool) -> Vec<clap::Arg> {
 
 fn main() {
     let matches = Command::new("dmgwiz")
-        .version("1.1.0")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Felix Seele <fseele@gmail.com>")
         .about("Extract filesystem data from DMG files")
         .subcommand_required(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn common_args(password_req: bool) -> Vec<clap::Arg> {
 
 fn main() {
     let matches = Command::new("dmgwiz")
-        .version("0.2.4")
+        .version("1.1.0")
         .author("Felix Seele <fseele@gmail.com>")
         .about("Extract filesystem data from DMG files")
         .subcommand_required(true)


### PR DESCRIPTION
This PR introduces a new function that helps handle XML data with trailing garbage. Some files contain XML sections where the declared length includes invalid data after a well-formed XML document ends, causing the plist parser to fail.

Bumped version from 1.0.0 to 1.1.0.