### PR TITLE
implement LZMA (ULMO)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +214,7 @@ dependencies = [
  "flate2",
  "itertools",
  "lzfse",
+ "lzma-rs",
  "num-derive",
  "num-traits",
  "openssl",
@@ -321,6 +337,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c80418f1cfc4601f8ef2055dcea77eebea47d2edc74ee0dadb005dd3a9f604"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ flate2 = "1"
 bzip2 = "0.4"
 adc = "0.2"
 lzfse = "0.2"
+lzma-rs = "0.3"
 quick-xml = "0.37.5"
 
 [dependencies.openssl]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DmgWiz
 
 DmgWiz lets you extract raw filesystem data from compressed and encrypted DMG files. It started as a [dmg2img](http://vu1tur.eu.org/tools/) clone but has more features and is more secure due to the Rust programming language.
 
-- Support for adc, zlib, bzip2 and lzfse compression
+- Support for adc, zlib, bzip2, lzfse and lzma compression
 - Support for encrypted DMGs (AES-128 and AES-256)
 - Runs on Windows, Linux, macOS
 
@@ -115,4 +115,3 @@ References
 TODO
 ----
 - verify checksums in DMG
-- add support for LZMA ("ULMO")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub enum ChunkType {
     ZLIB = 0x80000005,
     BZLIB = 0x80000006,
     LZFSE = 0x80000007,
+    LZMA = 0x80000008,
 
     Term = 0xffffffff,
 }
@@ -562,6 +563,7 @@ where
                 ChunkType::ZLIB => decode_zlib(&mut chunk_input, &mut output),
                 ChunkType::BZLIB => decode_bzlib(&mut chunk_input, &mut output),
                 ChunkType::LZFSE => decode_lzfse(&mut chunk_input, &mut output, out_len),
+                ChunkType::LZMA => decode_lzma(&mut chunk_input, &mut output),
                 ChunkType::Term => unreachable!(),
             };
 
@@ -634,6 +636,16 @@ fn decode_lzfse<R: Read, W: Write>(src: &mut R, dest: &mut W, dest_size: usize) 
 
     dest.write_all(&out_buf[..dest_size])?;
     Ok(len)
+}
+
+fn decode_lzma<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
+    // UDIF "LZMA" chunks are XZ streams (magic "\xfd7zXZ\x00").
+    let mut input = BufReader::new(src);
+    let mut out_buf = Vec::new();
+    lzma_rs::xz_decompress(&mut input, &mut out_buf)
+        .map_err(|_| Error::InvalidInput("lzma decompression failed".into()))?;
+    dest.write_all(&out_buf)?;
+    Ok(out_buf.len())
 }
 
 fn decode_adc<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,9 +639,9 @@ fn decode_lzfse<R: Read, W: Write>(src: &mut R, dest: &mut W, dest_size: usize) 
 }
 
 fn decode_lzma<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
-    // UDIF "LZMA" chunks are XZ streams (magic "\xfd7zXZ\x00").
     let mut input = BufReader::new(src);
     let mut out_buf = Vec::new();
+    // UDIF "LZMA" chunks are XZ streams (magic "\xfd7zXZ\x00").
     lzma_rs::xz_decompress(&mut input, &mut out_buf)
         .map_err(|_| Error::InvalidInput("lzma decompression failed".into()))?;
     dest.write_all(&out_buf)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,7 +641,7 @@ fn decode_lzfse<R: Read, W: Write>(src: &mut R, dest: &mut W, dest_size: usize) 
 fn decode_lzma<R: Read, W: Write>(src: &mut R, dest: &mut W) -> Result<usize> {
     let mut input = BufReader::new(src);
     let mut out_buf = Vec::new();
-    // UDIF "LZMA" chunks are XZ streams (magic "\xfd7zXZ\x00").
+    // UDIF "LZMA" chunks are actually XZ streams (magic "\xfd7zXZ\x00").
     lzma_rs::xz_decompress(&mut input, &mut out_buf)
         .map_err(|_| Error::InvalidInput("lzma decompression failed".into()))?;
     dest.write_all(&out_buf)?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -55,8 +55,6 @@ fn test_extract_all_lzfse() {
 }
 
 #[test]
-#[should_panic(expected = "unknown chunk type 0x80000008")]
-// lzma support is not implemented yet
 fn test_extract_all_lzma() {
     extract_all_test("tests/input_lzma.dmg", "tests/tmp_output_lzma.bin")
 }


### PR DESCRIPTION
fixes #24

addresses a limitation I bumped into when incorporating dmgwiz into our open-source detection pipeline (https://atomdrift.org/). 

Thank you so much for making this amazingly useful library!
